### PR TITLE
Drop 3.6 from ci

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@
          ############################################ replace above with this chunk when Windows testing gets worked out
          #os: [macos-latest, ubuntu-latest, windows-latest]
          ############################################
-         environment-file: [ci/36-GIT.yaml, ci/36-PYPI.yaml, ci/36-GIT-PLUS.yaml, ci/36-PYPI-PLUS.yaml, ci/37-GIT.yaml, ci/37-PYPI.yaml, ci/37-GIT-PLUS.yaml, ci/37-PYPI-PLUS.yaml, ci/38-GIT.yaml, ci/38-PYPI.yaml, ci/38-GIT-PLUS.yaml, ci/38-PYPI-PLUS.yaml]
+         environment-file: [ci/37-GIT.yaml, ci/37-PYPI.yaml, ci/37-GIT-PLUS.yaml, ci/37-PYPI-PLUS.yaml, ci/38-GIT.yaml, ci/38-PYPI.yaml, ci/38-GIT-PLUS.yaml, ci/38-PYPI-PLUS.yaml]
          ############################################ replace above with this chunk when Python 3.9 dependecies get worked out
          #environment-file: [ci/36-GIT.yaml, ci/36-PYPI.yaml, ci/36-GIT-PLUS.yaml, ci/36-PYPI-PLUS.yaml, ci/37-GIT.yaml, ci/37-PYPI.yaml, ci/37-GIT-PLUS.yaml, ci/37-PYPI-PLUS.yaml, ci/38-GIT.yaml, ci/38-PYPI.yaml, ci/38-GIT-PLUS.yaml, ci/38-PYPI-PLUS.yaml, ci/39-GIT.yaml, ci/39-PYPI.yaml, ci/39-GIT-PLUS.yaml, ci/39-PYPI-PLUS.yaml]
          ############################################

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ def setup_package():
             "Topic :: Scientific/Engineering :: GIS",
             "License :: OSI Approved :: BSD License",
             "Programming Language :: Python",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
         ],


### PR DESCRIPTION
We dropped 3.6 in libpysal so this is likely why spreg fails on https://github.com/pysal/spreg/pull/74