### PR TITLE
add dgp to docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -128,3 +128,27 @@ Diagnostic tests are useful for identifying model fit, sufficiency, and specific
     spreg.panel_rLMlag
     spreg.panel_rLMerror
     spreg.panel_Hausman
+
+DGP
+-----------
+
+Tools for simulating synthetic data according to different spatial data generating processes 
+
+.. autosummary:: 
+    :toctree: generated/
+
+    spreg.dgp.make_error
+    spreg.dgp.make_x
+    spreg.dgp.make_wx
+    spreg.dgp.make_xb
+    spreg.dgp.make_wxg
+    spreg.dgp.dgp_errproc
+    spreg.dgp.dgp_ols
+    spreg.dgp.dgp_slx
+    spreg.dgp.dgp_sperror
+    spreg.dgp.dgp_slxerror
+    spreg.dgp.dgp_lag
+    spreg.dgp.dgp_spdurbin
+    spreg.dgp.dgp_lagerr
+    spreg.dgp.dgp_gns
+    spreg.dgp.dgp_mes

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -132,7 +132,7 @@ Diagnostic tests are useful for identifying model fit, sufficiency, and specific
 DGP
 -----------
 
-Tools for simulating synthetic data according to different spatial data generating processes 
+Tools for simulating synthetic data according to data-generating processes implied by different spatial model specifications
 
 .. autosummary:: 
     :toctree: generated/


### PR DESCRIPTION
I think all of these are public? This will add this block to the docs:
<img width="1012" alt="Screenshot 2024-06-24 at 3 51 06 PM" src="https://github.com/pedrovma/spreg-1/assets/4213368/15cf3339-59ab-46d8-99d4-32a200a8d151">


(though you can see I updated the description to "Tools for simulating synthetic data according to data-generating processes implied by different spatial model specifications"  not sure what you'd prefer)